### PR TITLE
[REP-366 -> master] API - Check for existing user based on email

### DIFF
--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -12,6 +12,10 @@ export class UserService {
         return await this.connector.axios.get(`/users`, {baseURL: this.connector.config.baseURL});
     }
 
+    async getUserByEmail(primaryEmailAddress: string) {
+        return await this.connector.axios.get(`/users/${primaryEmailAddress}/emailExists`, {baseURL: this.connector.config.baseURL});
+    }
+
     async createUser(primaryEmailAddress: string, firstName: string, lastName: string, password: string, confirmPassword: string, organizationIds: string[]) {
         const payload = {
             primaryEmailAddress, 


### PR DESCRIPTION
REP-366 Added user check by email address

There is a new method in the user service that makes a call to the reperio core/platform API that returns true if a user exists with the provided email or false if there isn't.