### PR TITLE
[REP-389 -> master] Create new core API signup to take additional parameters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,14 @@
 export { ReperioCoreConnectorConfig, ReperioCoreConnector } from "./services/connector";
 export { Application } from "./models/application";
 export { Organization } from "./models/organization";
+export { OrganizationAddress } from "./models/organizationAddress";
 export { Permission, CorePermissions } from "./models/permission";
 export { Role } from "./models/role";
 export { RolePermission } from "./models/rolePermission";
+export { SurveyPayload } from "./models/surveyPayload";
 export { User } from "./models/user";
 export { UserEmail } from "./models/userEmail";
 export { UserOrganization } from "./models/userOrganization";
+export { UserPhone } from "./models/userPhone";
 export { UserRole } from "./models/userRole";
 export { AuthConnector } from "./components/authConnector";

--- a/src/models/organization.ts
+++ b/src/models/organization.ts
@@ -1,8 +1,10 @@
 import { UserOrganization } from "./userOrganization";
+import { OrganizationAddress } from "./organizationAddress";
 
 export interface Organization {
     id: string;
     name: string;
     userOrganizations: UserOrganization[];
+    organizationAddress: OrganizationAddress[];
     personal: boolean;
 }

--- a/src/models/organizationAddress.ts
+++ b/src/models/organizationAddress.ts
@@ -1,0 +1,12 @@
+import { Organization } from "./organization";
+
+export interface OrganizationAddress {
+    id: string;
+    organizationId: string;
+    organization: Organization;
+    streetAddress: string;
+    suiteNumber: string;
+    city: string;
+    state: string;
+    zip: string;
+}

--- a/src/models/surveyPayload.ts
+++ b/src/models/surveyPayload.ts
@@ -1,0 +1,11 @@
+import { UserOrganization } from "./userOrganization";
+import { UserPhone } from "./userPhone";
+
+export interface SurveyPayload {
+    primaryEmailAddress: string;
+    firstName: string;
+    lastName: string;
+    phones: UserPhone[];
+    organizations: UserOrganization[];
+    sendConfirmationEmail: boolean;
+}

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,6 +1,7 @@
 import { UserOrganization } from "./userOrganization";
 import { UserRole } from "./userRole";
 import { UserEmail } from "./userEmail";
+import { UserPhone } from "./userPhone";
 
 export interface User {
     id: string;
@@ -11,5 +12,6 @@ export interface User {
     userOrganizations: UserOrganization[];
     userRoles: UserRole[];
     userEmails: UserEmail[];
+    userPhones: UserPhone[];
     primaryEmailAddress: string;
 }

--- a/src/models/userPhone.ts
+++ b/src/models/userPhone.ts
@@ -1,0 +1,9 @@
+import { User } from "./user";
+
+export interface UserPhone {
+    userId: string;
+    user: User;
+    numberVerified: boolean;
+    number: string;
+    phoneType: string;
+}

--- a/src/services/applicationService.ts
+++ b/src/services/applicationService.ts
@@ -1,4 +1,5 @@
 import {ReperioCoreConnector} from "./connector";
+import {SurveyPayload} from "../models/surveyPayload";
 
 export class ApplicationService {
     constructor(public connector: ReperioCoreConnector) { }
@@ -9,5 +10,9 @@ export class ApplicationService {
 
     async getApplications() {
         return await this.connector.axios.get(`/applications`, {baseURL: this.connector.config.baseURL});
+    }
+
+    async surveyUserSignup(applicationId: string, surveyPayload: SurveyPayload) {
+        return await this.connector.axios.post(`/applications/${applicationId}/userSignup`, surveyPayload, {baseURL: this.connector.config.baseURL});
     }
 }

--- a/src/services/applicationService.ts
+++ b/src/services/applicationService.ts
@@ -1,6 +1,12 @@
 import {ReperioCoreConnector} from "./connector";
 import {SurveyPayload} from "../models/surveyPayload";
 
+interface SurveyResponse {
+    success: boolean;
+    errors: string[];
+
+}
+
 export class ApplicationService {
     constructor(public connector: ReperioCoreConnector) { }
 
@@ -12,7 +18,8 @@ export class ApplicationService {
         return await this.connector.axios.get(`/applications`, {baseURL: this.connector.config.baseURL});
     }
 
-    async surveyUserSignup(applicationId: string, surveyPayload: SurveyPayload) {
-        return await this.connector.axios.post(`/applications/${applicationId}/userSignup`, surveyPayload, {baseURL: this.connector.config.baseURL});
+    async surveyUserSignup(applicationId: string, surveyPayload: SurveyPayload) : Promise<SurveyResponse> {
+        const response = await this.connector.axios.post(`/applications/${applicationId}/userSignup`, surveyPayload, {baseURL: this.connector.config.baseURL});
+        return response.data;
     }
 }


### PR DESCRIPTION
REP-389 added method to accept the userRegistration payload

Created a few new models and created a new method that accepts the survey signup payload and makes the request to the reperio core/platform API